### PR TITLE
小数点数ジャッジに絶対誤差比較も追加する

### DIFF
--- a/mojacoder-backend/judge-image/check.go
+++ b/mojacoder-backend/judge-image/check.go
@@ -24,7 +24,8 @@ func compareValue(answer string, solution string, accuracy float64) bool {
 			} else if math.IsNaN(numberC) {
 				return math.IsNaN(numberA)
 			} else {
-				return math.Abs(numberC-numberA) <= math.Abs(accuracy*numberC)
+				// 相対誤差もしくは絶対誤差が accuracy 以下なら AC
+				return math.Abs(numberC-numberA) <= math.Abs(accuracy*numberC) || math.Abs(numberC-numberA) <= accuracy
 			}
 		} else {
 			return false


### PR DESCRIPTION
相対誤差だけだと正答が 0.1 のときに 0.100001 が通らないので