### PR TITLE
小数ジャッジの精度の改善

### DIFF
--- a/mojacoder-backend/judge-image/Dockerfile
+++ b/mojacoder-backend/judge-image/Dockerfile
@@ -9,8 +9,12 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
 RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
 RUN apt update
 
-RUN apt install -y golang-1.14
-ENV PATH $PATH:/usr/lib/go-1.14/bin/
+RUN apt install -y software-properties-common
+RUN add-apt-repository ppa:longsleep/golang-backports
+RUN apt update
+RUN apt install -y golang-1.21-go
+ENV PATH $PATH:/usr/lib/go-1.21/bin
+
 RUN apt install -y python3.8 build-essential mono-devel bf cargo pypy3 ruby2.7 default-jdk sbcl
 
 WORKDIR /tmp

--- a/mojacoder-backend/judge-image/judge.go
+++ b/mojacoder-backend/judge-image/judge.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+const PRECISION = 128
 
 type TestcaseResultInput struct {
 	Name   string `json:"name"`
@@ -111,7 +114,8 @@ func judge(definition LanguageDefinition, data JudgeQueueData) error {
 			continue
 		}
 		stdoutReader := strings.NewReader(stdoutWriter.String())
-		checkResult, err := check(stdoutReader, outTestcaseFile, 0.000001)
+		accuracy, _, _ := big.ParseFloat("0.000001", 10, PRECISION, big.ToNearestEven)
+		checkResult, err := check(stdoutReader, outTestcaseFile, accuracy, PRECISION)
 		if err != nil {
 			return fmt.Errorf(errorMessage, err)
 		}


### PR DESCRIPTION
## 発生している問題
浮動小数点数比較では、想定誤差内であるにも関わらずWrong Answer の判定が出るケースが存在する。

[具体例]

想定解： "16777215.0"  
出力解： "16777231.777215"

[提出](https://mojacoder.app/users/shinnshinn/problems/test-float/submissions/0224fb41-6366-4ad3-99d5-c0b197fe3c17)


## 対処法
strconv.ParseFloatを使う代わりに精度の良いbig.Floatを利用する。


## 変更点
浮動小数点数の比較の精度を向上させるためにcompareValue関数にいくつかの変更を加えました：

1. `big.Float`の導入
   128ビットの精度を持つbig.Floatを使用して小数の比較を行います。これにより倍精度浮動小数点数よりもより良い精度を得ることができます。

2. 十進数の検証
   標準表記（例："1.23"）を検証する`isValidDecimal`関数を追加。
   
   big.Floatは科学的表記を受け入れるが、これはジャッジの挙動としては望ましくないため標準表記の数値に限定。


注：128ビットの精度値はjudge-image/judge.goにてPRECISIONとして定義しており変更が可能です。


## judge-image/Dockerfileの更新
golangを1.14から1.21へと更新しました。

big.Floatは1.14ではいくつかのバグが報告されています。正常に動作させるためにもバージョンを変更しました。
