### PR TITLE
ジャッジのメモリに関する不具合修正

### DIFF
--- a/mojacoder-backend/judge-image/judge.go
+++ b/mojacoder-backend/judge-image/judge.go
@@ -88,7 +88,7 @@ func judge(definition LanguageDefinition, data JudgeQueueData) error {
 			return fmt.Errorf(errorMessage, err)
 		}
 		stdoutWriter := strings.Builder{}
-		result, err := run(definition, inTestcaseFile, &stdoutWriter, nil, 2, 262144)
+		result, err := run(definition, inTestcaseFile, &stdoutWriter, nil, 2, 1024*1024)
 		if err != nil {
 			return fmt.Errorf(errorMessage, err)
 		}

--- a/mojacoder-backend/judge-image/run.go
+++ b/mojacoder-backend/judge-image/run.go
@@ -27,7 +27,8 @@ type RunResult struct {
 func run(definition LanguageDefinition, stdin io.Reader, stdout io.Writer, stderr io.Writer, timeLimit, memoryLimit int) (RunResult, error) {
 	var result RunResult
 	var err error
-	command := fmt.Sprintf("ulimit -u 32 -m %d && timeout --preserve-status -sSIGKILL %d %s; EXIT_CODE=$?; kill -SIGKILL -1; wait; exit $EXIT_CODE", memoryLimit, timeLimit, definition.RunCommand)
+	additional_memory := 5 * 1024
+	command := fmt.Sprintf("ulimit -u 32 -v %d && timeout --preserve-status -sSIGKILL %d %s; EXIT_CODE=$?; kill -SIGKILL -1; wait; exit $EXIT_CODE", memoryLimit+additional_memory, timeLimit, definition.RunCommand)
 	cmd := exec.Command("bash", "-c", command)
 	cmd.Env = []string{}
 	cmd.Dir = TEMP_DIR
@@ -47,14 +48,13 @@ func run(definition LanguageDefinition, stdin io.Reader, stdout io.Writer, stder
 	result.exitCode = cmd.ProcessState.ExitCode()
 	result.time = int((end.Sub(start)).Milliseconds())
 	result.memory = int(cmd.ProcessState.SysUsage().(*syscall.Rusage).Maxrss)
-	if !cmd.ProcessState.Success() {
-		if result.time > timeLimit*1000 {
-			result.status = RunResultStatusTimeLimitExceeded
-		} else if result.memory > memoryLimit {
-			result.status = RunResultStatusMemoryLimitExceeded
-		} else {
-			result.status = RunResultStatusRunTimeError
-		}
+
+	if result.time > timeLimit*1000 {
+		result.status = RunResultStatusTimeLimitExceeded
+	} else if result.memory > memoryLimit {
+		result.status = RunResultStatusMemoryLimitExceeded
+	} else if !cmd.ProcessState.Success() {
+		result.status = RunResultStatusRunTimeError
 	}
 	return result, nil
 }


### PR DESCRIPTION
## 問題点
[1] メモリ制限が256MBになっている

`judge.go`で設定されているメモリ制限が262144KiB(256 MiB)となっています。問題ページにはメモリは1024MBとあるのでジャッジと差があります。

[2] メモリ制限を超えてもAC判定となる

プログラム実行時に実行エラーがでなければメモリ使用量の検証が行われないためACの判定が出る場合があります。

以下の提出ではメモリ使用量は1502MBであるのにも関わらずACが出ます。

[提出リンク](https://mojacoder.app/users/shinnshinn/problems/test-mem/submissions/0c4f7863-b41c-4628-96c4-2e91eadfeffd)

また、`ulimit`の`-m`は物理メモリの使用量制限のためスワップが含まれません。

## 解決策
`judge.go`で設定されているメモリ制限を1024 MiBに変更しました。

終了ステータスに関わらずメモリ使用量を確認するように変更しました。

`ulimit`でのメモリ制限を`-m`から`-v`へ変更しました。`-v`はバーチャルメモリ制限であり、物理メモリ＋スワップメモリで計算されます。

また、メモリ制限は5MiBほど余裕を持たせて制限するようにしていますが、終了ステータスに関わらず使用量を確認するため問題ありません。
