### PR TITLE
一覧リンクのviewport prefetchを抑制する

### DIFF
--- a/mojacoder-frontend/components/ContestsTable.tsx
+++ b/mojacoder-frontend/components/ContestsTable.tsx
@@ -34,6 +34,7 @@ export const ContestsTable: React.FC<Props> = ({ contests }) => {
                         <td className="text-nowrap">
                             <Link
                                 href={`/users/${item.user.detail.screenName}/contests/${item.slug}`}
+                                prefetch={false}
                             >
                                 {item.name}
                             </Link>

--- a/mojacoder-frontend/components/SubmissionTable.tsx
+++ b/mojacoder-frontend/components/SubmissionTable.tsx
@@ -60,6 +60,7 @@ const SubmissionTableRow: React.FC<SubmissionTableRowProps> = (props) => {
                             id,
                         },
                     }}
+                    prefetch={false}
                 >
                     詳細
                 </Link>

--- a/mojacoder-frontend/components/Username.tsx
+++ b/mojacoder-frontend/components/Username.tsx
@@ -13,7 +13,10 @@ const Username: React.FC<UsernameProps> = ({ children }) => {
             {children === null ? (
                 <span>Guest</span>
             ) : (
-                <Link href={`/users/${children?.screenName}`}>
+                <Link
+                    href={`/users/${children?.screenName}`}
+                    prefetch={false}
+                >
                     {children?.screenName}
                 </Link>
             )}

--- a/mojacoder-frontend/containers/SubmissionPage.tsx
+++ b/mojacoder-frontend/containers/SubmissionPage.tsx
@@ -112,6 +112,7 @@ const SubmissionPage: React.FC<SubmissionPageProps> = ({ submission }) => {
                                             testcaseName: testcase.name,
                                         },
                                     }}
+                                    prefetch={false}
                                 >
                                     {testcase.name}
                                 </Link>

--- a/mojacoder-frontend/pages/problems/index.tsx
+++ b/mojacoder-frontend/pages/problems/index.tsx
@@ -85,6 +85,7 @@ export const Post: React.FC<Props> = ({ newProblems, nextToken }) => {
                                     )}
                                     <Link
                                         href={`/users/${item.user.detail.screenName}/problems/${item.slug}`}
+                                        prefetch={false}
                                     >
                                         {item.title}
                                     </Link>

--- a/mojacoder-frontend/pages/users/[username]/contests/[contestSlug]/tasks/index.tsx
+++ b/mojacoder-frontend/pages/users/[username]/contests/[contestSlug]/tasks/index.tsx
@@ -101,6 +101,7 @@ const ContestTasks: React.FC<Props> = ({ contest }) => {
                                         <td className="text-nowrap">
                                             <Link
                                                 href={`/users/${username}/contests/${contestSlug}/tasks/${index}`}
+                                                prefetch={false}
                                             >
                                                 {item.problem.detail.title}
                                             </Link>

--- a/mojacoder-frontend/pages/users/[username]/contests/index.tsx
+++ b/mojacoder-frontend/pages/users/[username]/contests/index.tsx
@@ -70,6 +70,7 @@ const Contests: React.FC<Props> = ({ user }) => {
                                 <td className="text-nowrap">
                                     <Link
                                         href={`/users/${user.screenName}/contests/${item.slug}`}
+                                        prefetch={false}
                                     >
                                         {item.name}
                                     </Link>

--- a/mojacoder-frontend/pages/users/[username]/index.tsx
+++ b/mojacoder-frontend/pages/users/[username]/index.tsx
@@ -72,6 +72,7 @@ const UserPage: React.FC<Props> = ({ user }) => {
                                 <td className="text-nowrap">
                                     <Link
                                         href={`/users/${user.screenName}/problems/${item.slug}`}
+                                        prefetch={false}
                                     >
                                         {item.title}
                                     </Link>

--- a/mojacoder-frontend/pages/users/[username]/problems/[problemSlug]/testcases/index.tsx
+++ b/mojacoder-frontend/pages/users/[username]/problems/[problemSlug]/testcases/index.tsx
@@ -48,6 +48,7 @@ const Submissions: React.FC<Props> = ({ problem }) => {
                                                     testcaseName: name,
                                                 },
                                             }}
+                                            prefetch={false}
                                         >
                                             {name}
                                         </Link>


### PR DESCRIPTION
## 概要

一覧画面に多数表示されるNext.js `Link` の自動prefetchを抑制します。

viewport内のリンクが一斉にprefetchされることで発生し得る、Amplify・ISR・AppSyncへの不要なアクセスを減らすことが目的です。

## 変更内容

- `Username` 内のユーザーページリンクを常に `prefetch={false}` に変更
- 以下の反復表示リンクへ `prefetch={false}` を追加
  - 問題一覧
  - コンテスト一覧
  - 提出詳細
  - コンテストタスク
  - テストケース
- Appbar、認証、設定、詳細画面のタブなど、固定本数のナビゲーションは変更しない
- 通常クリックによるページ遷移は従来どおり維持

## 確認内容

- `yarn lint`
- `yarn type-check`
- `yarn test --runInBand`
  - 4 suites / 10 tests passed

## 注意事項

Next.js 14のPages Routerでは、`prefetch={false}` を指定してもhover時のprefetchは残ります。このPRでは低リスクな第一段階として、viewportに入った際の自動prefetchのみを停止します。

`revalidate`、アイコン機能、AWS/CDK設定は変更していません。