### PR TITLE
テストケース内容の閲覧にCognito認証を必須化

### DIFF
--- a/mojacoder-backend/graphql/schema.graphql
+++ b/mojacoder-backend/graphql/schema.graphql
@@ -61,8 +61,8 @@ type LikerConnection {
 type Testcase {
   problemID: ID
   name: String
-  inUrl: AWSURL
-  outUrl: AWSURL
+  inUrl: AWSURL @aws_cognito_user_pools
+  outUrl: AWSURL @aws_cognito_user_pools
 }
 
 enum ProblemStatus {
@@ -103,7 +103,7 @@ type ProblemDetail @aws_cognito_user_pools @aws_api_key @aws_iam {
   editorial: String
   hasDifficulty: Boolean
   difficulty: String
-  testcase(name: String!): Testcase
+  testcase(name: String!): Testcase @aws_cognito_user_pools
   testcaseNames: [String]!
   submission(id: ID!): Submission
   submissions(nextToken: String, userID: ID): SubmissionConnection!

--- a/mojacoder-backend/test/testcase-auth.test.ts
+++ b/mojacoder-backend/test/testcase-auth.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const schema = readFileSync(join(__dirname, '../graphql/schema.graphql'), 'utf8');
+
+test('requires Cognito authentication for testcase contents', () => {
+    const testcaseField = schema
+        .split(/\r?\n/)
+        .find(line => line.includes('testcase(name:'));
+    const inUrlField = schema
+        .split(/\r?\n/)
+        .find(line => line.includes('inUrl: AWSURL'));
+    const outUrlField = schema
+        .split(/\r?\n/)
+        .find(line => line.includes('outUrl: AWSURL'));
+
+    for (const field of [testcaseField, inUrlField, outUrlField]) {
+        expect(field).toContain('@aws_cognito_user_pools');
+        expect(field).not.toContain('@aws_api_key');
+        expect(field).not.toContain('@aws_iam');
+    }
+});

--- a/mojacoder-frontend/pages/users/[username]/problems/[problemSlug]/testcases/[testcaseName].tsx
+++ b/mojacoder-frontend/pages/users/[username]/problems/[problemSlug]/testcases/[testcaseName].tsx
@@ -3,9 +3,13 @@ import { GetStaticPaths, GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
 import gql from 'graphql-tag'
 import axios from 'axios'
-import { ProgressBar } from 'react-bootstrap'
+import { Alert, ProgressBar } from 'react-bootstrap'
 
-import { invokeQueryWithApiKey } from '../../../../../../lib/backend'
+import Auth from '../../../../../../lib/auth'
+import {
+    invokeQuery,
+    invokeQueryWithApiKey,
+} from '../../../../../../lib/backend'
 import { ProblemDetail } from '../../../../../../lib/backend_types'
 import Editor from '../../../../../../components/Editor'
 import Layout from '../../../../../../components/Layout'
@@ -34,45 +38,102 @@ const GetTestcase = gql`
 interface Props {
     problem: ProblemDetail
 }
+
+const Status = {
+    Loading: 'Loading',
+    Done: 'Done',
+    Error: 'Error',
+} as const
+type Status = typeof Status[keyof typeof Status]
+
 const Submissions: React.FC<Props> = ({ problem }) => {
+    const { auth } = Auth.useContainer()
     const { query } = useRouter()
     const { username, problemSlug, testcaseName } = query
     const [inTestcase, setInTestcase] = useState<string | null>(null)
     const [outTestcase, setOutTestcase] = useState<string | null>(null)
+    const [status, setStatus] = useState<Status>(Status.Loading)
     useEffect(() => {
-        invokeQueryWithApiKey(GetTestcase, {
-            authorUsername: username,
-            problemSlug: problemSlug,
-            testcaseName: testcaseName,
-        }).then(({ user }) => {
-            axios
-                .get(user.problem.testcase.inUrl, {
-                    transformResponse: (value) => value,
+        if (
+            !auth ||
+            typeof username !== 'string' ||
+            typeof problemSlug !== 'string' ||
+            typeof testcaseName !== 'string'
+        ) {
+            return
+        }
+
+        let active = true
+        setStatus(Status.Loading)
+        setInTestcase(null)
+        setOutTestcase(null)
+
+        const loadTestcase = async () => {
+            try {
+                const { user } = await invokeQuery(GetTestcase, {
+                    authorUsername: username,
+                    problemSlug,
+                    testcaseName,
                 })
-                .then(({ data }) => {
-                    setInTestcase(String(data))
-                })
-            axios
-                .get(user.problem.testcase.outUrl, {
-                    transformResponse: (value) => value,
-                })
-                .then(({ data }) => {
-                    setOutTestcase(String(data))
-                })
-        })
-    }, [query, setInTestcase, setOutTestcase])
+                const testcase = user?.problem?.testcase
+                if (!testcase) {
+                    throw new Error('Testcase not found')
+                }
+                const [inResponse, outResponse] = await Promise.all([
+                    axios.get(testcase.inUrl, {
+                        transformResponse: (value) => value,
+                    }),
+                    axios.get(testcase.outUrl, {
+                        transformResponse: (value) => value,
+                    }),
+                ])
+                if (!active) {
+                    return
+                }
+                setInTestcase(String(inResponse.data))
+                setOutTestcase(String(outResponse.data))
+                setStatus(Status.Done)
+            } catch (error) {
+                console.error(error)
+                if (active) {
+                    setStatus(Status.Error)
+                }
+            }
+        }
+        loadTestcase()
+
+        return () => {
+            active = false
+        }
+    }, [auth, username, problemSlug, testcaseName])
     return (
         <>
             <Title>{`'${problem.title}'のテストケース`}</Title>
             <ProblemTop activeKey="testcases" problem={problem} />
             <Layout>
                 <Heading>{testcaseName}</Heading>
-                <h3>入力</h3>
-                {!inTestcase && <ProgressBar animated now={100} />}
-                <Editor value={inTestcase || ''} readOnly />
-                <h3>出力</h3>
-                {!outTestcase && <ProgressBar animated now={100} />}
-                <Editor value={outTestcase || ''} readOnly />
+                {!auth ? (
+                    <Alert variant="danger">
+                        テストケースを閲覧するにはサインインしてください。
+                    </Alert>
+                ) : status === Status.Error ? (
+                    <Alert variant="danger">
+                        テストケースを取得できませんでした。
+                    </Alert>
+                ) : (
+                    <>
+                        <h3>入力</h3>
+                        {status === Status.Loading && (
+                            <ProgressBar animated now={100} />
+                        )}
+                        <Editor value={inTestcase || ''} readOnly />
+                        <h3>出力</h3>
+                        {status === Status.Loading && (
+                            <ProgressBar animated now={100} />
+                        )}
+                        <Editor value={outTestcase || ''} readOnly />
+                    </>
+                )}
             </Layout>
         </>
     )


### PR DESCRIPTION
## 概要

テストケースの入力・出力を、未認証のAPIキー経由では取得できないようにします。

## 変更内容

- テストケース取得画面をCognito認証済みクライアントへ変更
- 未ログイン時は取得リクエストを送らず、サインイン要求を表示
- AppSyncの以下のフィールドをCognito認証専用に変更
  - `ProblemDetail.testcase`
  - `Testcase.inUrl`
  - `Testcase.outUrl`
- 認証設定の回帰テストを追加
- 取得失敗時のエラー表示を追加

## 影響範囲

- テストケース名の一覧は引き続き公開されます
- 入力・出力の実データのみ認証必須になります
- ジャッジ用テストケースの保存・実行処理には影響しません
- 所有者限定ではなく、Cognitoへサインイン済みのユーザーが閲覧できます

## 確認内容

- Backend: 17 tests passed
- Frontend: 10 tests passed
- Frontend type-check passed
- 対象ファイルのLint passed