### PR TITLE
問題文ページ以外をクロール・インデックス対象外にする

### DIFF
--- a/mojacoder-frontend/components/SearchEnginePolicy.tsx
+++ b/mojacoder-frontend/components/SearchEnginePolicy.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import Head from 'next/head'
+
+export const problemStatementPathname =
+    '/users/[username]/problems/[problemSlug]'
+
+export const isProblemStatementPage = (pathname: string): boolean =>
+    pathname === problemStatementPathname
+
+interface Props {
+    pathname: string
+}
+
+const SearchEnginePolicy: React.FC<Props> = ({ pathname }) => {
+    if (isProblemStatementPage(pathname)) {
+        return null
+    }
+
+    return (
+        <Head>
+            <meta key="robots" name="robots" content="noindex,nofollow" />
+        </Head>
+    )
+}
+
+export default SearchEnginePolicy

--- a/mojacoder-frontend/pages/_app.tsx
+++ b/mojacoder-frontend/pages/_app.tsx
@@ -10,6 +10,7 @@ import Session from '../lib/session'
 import Appbar from '../containers/Appbar'
 import Authenticate from '../containers/Authenticate'
 import ServiceTerminationAlert from '../components/ServiceTerminationAlert'
+import SearchEnginePolicy from '../components/SearchEnginePolicy'
 
 import 'nprogress/nprogress.css'
 import 'bootstrap/dist/css/bootstrap.min.css'
@@ -331,12 +332,13 @@ const languages = {
 }
 
 const App = ({ Component, pageProps }: AppProps) => {
-    const { locale } = useRouter()
+    const { locale, pathname } = useRouter()
     return (
         <I18nProvider defaultLanguage="ja" lang={locale} languages={languages}>
             <Auth.Provider>
                 <Authenticate />
                 <Session.Provider>
+                    <SearchEnginePolicy pathname={pathname} />
                     <Head>
                         <title>MojaCoder</title>
                         <link rel="manifest" href="/manifest.json" />

--- a/mojacoder-frontend/pages/robots.txt.tsx
+++ b/mojacoder-frontend/pages/robots.txt.tsx
@@ -11,7 +11,6 @@ export const createRobotsTxt = (origin: string): string => `User-agent: *
 Disallow: /
 Allow: /sitemap.xml$
 Allow: /_next/static/
-Allow: /images/
 Allow: /users/*/problems/*$
 Disallow: /users/*/problems/*/*
 Allow: /en/users/*/problems/*$

--- a/mojacoder-frontend/pages/robots.txt.tsx
+++ b/mojacoder-frontend/pages/robots.txt.tsx
@@ -5,9 +5,24 @@ export const RobotsTxt: React.FC = () => null
 
 export default RobotsTxt
 
+// A wildcard can also match `/`, so each problem-page Allow needs a longer
+// child-path Disallow to keep submissions, testcases, and other nested pages out.
+export const createRobotsTxt = (origin: string): string => `User-agent: *
+Disallow: /
+Allow: /sitemap.xml$
+Allow: /_next/static/
+Allow: /images/
+Allow: /users/*/problems/*$
+Disallow: /users/*/problems/*/*
+Allow: /en/users/*/problems/*$
+Disallow: /en/users/*/problems/*/*
+
+Sitemap: ${origin}/sitemap.xml
+`
+
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader('Content-Type', 'text/plain')
-    res.end(`Sitemap: ${process.env.ORIGIN}/sitemap.xml\n`)
+    res.end(createRobotsTxt(process.env.ORIGIN))
     return {
         props: {},
     }

--- a/mojacoder-frontend/test/components/SearchEnginePolicy.test.tsx
+++ b/mojacoder-frontend/test/components/SearchEnginePolicy.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import SearchEnginePolicy, {
+    isProblemStatementPage,
+    problemStatementPathname,
+} from '../../components/SearchEnginePolicy'
+import { render } from '../testUtils'
+
+jest.mock('next/head', () => ({ children }) => children)
+
+describe('SearchEnginePolicy', () => {
+    it('allows the canonical problem statement page to be indexed', () => {
+        const { container } = render(
+            <SearchEnginePolicy pathname={problemStatementPathname} />
+        )
+
+        expect(isProblemStatementPage(problemStatementPathname)).toBe(true)
+        expect(container.querySelector('meta[name="robots"]')).toBeNull()
+    })
+
+    it.each([
+        '/',
+        '/problems',
+        '/users/[username]',
+        '/users/[username]/problems/[problemSlug]/submissions',
+        '/users/[username]/problems/[problemSlug]/testcases',
+        '/users/[username]/problems/[problemSlug]/testcases/[testcaseName]',
+        '/users/[username]/contests/[contestSlug]/tasks/[taskNumber]',
+    ])('prevents indexing and link following on %s', (pathname) => {
+        const { container } = render(<SearchEnginePolicy pathname={pathname} />)
+
+        expect(isProblemStatementPage(pathname)).toBe(false)
+        expect(
+            container
+                .querySelector('meta[name="robots"]')
+                ?.getAttribute('content')
+        ).toBe('noindex,nofollow')
+    })
+})

--- a/mojacoder-frontend/test/pages/robots.txt.test.ts
+++ b/mojacoder-frontend/test/pages/robots.txt.test.ts
@@ -62,15 +62,12 @@ describe('robots.txt', () => {
         '/users/alice/problems/a-plus-b/editorial',
         '/en/users/alice/problems/a-plus-b/submissions',
         '/users/alice/contests/spring/tasks/1',
+        '/images/logo.svg',
     ])('disallows crawling a non-problem-statement URL: %s', (pathname) => {
         expect(isCrawlAllowed(robotsTxt, pathname)).toBe(false)
     })
 
-    it.each([
-        '/sitemap.xml',
-        '/_next/static/chunks/main.js',
-        '/images/logo.svg',
-    ])(
+    it.each(['/sitemap.xml', '/_next/static/chunks/main.js'])(
         'allows a resource needed for discovery or rendering: %s',
         (pathname) => {
             expect(isCrawlAllowed(robotsTxt, pathname)).toBe(true)

--- a/mojacoder-frontend/test/pages/robots.txt.test.ts
+++ b/mojacoder-frontend/test/pages/robots.txt.test.ts
@@ -1,0 +1,104 @@
+import { createRobotsTxt, getServerSideProps } from '../../pages/robots.txt'
+
+interface RobotsRule {
+    allow: boolean
+    path: string
+}
+
+const parseRules = (robotsTxt: string): RobotsRule[] =>
+    robotsTxt
+        .split('\n')
+        .map((line) => /^(Allow|Disallow): (.+)$/.exec(line))
+        .filter((match): match is RegExpExecArray => match !== null)
+        .map((match) => ({
+            allow: match[1] === 'Allow',
+            path: match[2],
+        }))
+
+const pathPatternToRegExp = (pathPattern: string): RegExp => {
+    const matchesEnd = pathPattern.endsWith('$')
+    const pattern = matchesEnd ? pathPattern.slice(0, -1) : pathPattern
+    const source = pattern
+        .split('*')
+        .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('.*')
+    return new RegExp(`^${source}${matchesEnd ? '$' : ''}`)
+}
+
+const isCrawlAllowed = (robotsTxt: string, pathname: string): boolean => {
+    const matchingRules = parseRules(robotsTxt).filter((rule) =>
+        pathPatternToRegExp(rule.path).test(pathname)
+    )
+    if (matchingRules.length === 0) {
+        return true
+    }
+    const longestPath = Math.max(
+        ...matchingRules.map((rule) => rule.path.replace(/[*$]/g, '').length)
+    )
+    return matchingRules
+        .filter((rule) => rule.path.replace(/[*$]/g, '').length === longestPath)
+        .some((rule) => rule.allow)
+}
+
+describe('robots.txt', () => {
+    const robotsTxt = createRobotsTxt('https://mojacoder.example')
+
+    it.each([
+        '/users/alice/problems/a-plus-b',
+        '/en/users/alice/problems/a-plus-b',
+        '/users/alice/problems/a-plus-b?source=search',
+    ])('allows crawling a canonical problem statement URL: %s', (pathname) => {
+        expect(isCrawlAllowed(robotsTxt, pathname)).toBe(true)
+    })
+
+    it.each([
+        '/',
+        '/problems',
+        '/users/alice',
+        '/users/alice/problems/a-plus-b/submissions',
+        '/users/alice/problems/a-plus-b/submissions/123',
+        '/users/alice/problems/a-plus-b/testcases',
+        '/users/alice/problems/a-plus-b/testcases/sample-1',
+        '/users/alice/problems/a-plus-b/editorial',
+        '/en/users/alice/problems/a-plus-b/submissions',
+        '/users/alice/contests/spring/tasks/1',
+    ])('disallows crawling a non-problem-statement URL: %s', (pathname) => {
+        expect(isCrawlAllowed(robotsTxt, pathname)).toBe(false)
+    })
+
+    it.each([
+        '/sitemap.xml',
+        '/_next/static/chunks/main.js',
+        '/images/logo.svg',
+    ])(
+        'allows a resource needed for discovery or rendering: %s',
+        (pathname) => {
+            expect(isCrawlAllowed(robotsTxt, pathname)).toBe(true)
+        }
+    )
+
+    it('serves the policy as plain text without changing the sitemap URL', async () => {
+        const previousOrigin = process.env.ORIGIN
+        process.env.ORIGIN = 'https://mojacoder.example'
+        const setHeader = jest.fn()
+        const end = jest.fn()
+
+        try {
+            await getServerSideProps({
+                res: { setHeader, end },
+            } as any)
+        } finally {
+            if (previousOrigin === undefined) {
+                delete process.env.ORIGIN
+            } else {
+                process.env.ORIGIN = previousOrigin
+            }
+        }
+
+        expect(setHeader).toHaveBeenCalledWith('Content-Type', 'text/plain')
+        expect(end).toHaveBeenCalledWith(robotsTxt)
+        expect(robotsTxt).toContain(
+            'Sitemap: https://mojacoder.example/sitemap.xml\n'
+        )
+    })
+})


### PR DESCRIPTION
## 概要

検索エンジンや善良なクローラーが、問題文以外のページへアクセス・インデックスしないようSEO制御を追加します。

## 変更内容

- `robots.txt` をデフォルト拒否に変更
- 日本語・英語の正規問題文URLのみクロールを許可
- 提出、テストケース、解説、コンテストなどのページをクロール対象外に設定
- sitemapとNext.jsの静的リソースのみ例外として許可
- 問題文ページ以外へ `noindex,nofollow` を共通設定
- 動的URLとrobots.txtの最長一致を検証する回帰テストを追加

## 変更しないもの

- sitemapの掲載内容
- 認証・S3データ
- AWSリソース・AppSync WAF

## 検証

- Frontendテスト: 35件成功
- TypeScript型検査: 成功
- 対象ファイルのESLint: 成功