### PR TITLE
feat(frontend): AdSenseを復元し、操作を妨げない広告配置を追加

### DIFF
--- a/mojacoder-frontend/components/AdSense.tsx
+++ b/mojacoder-frontend/components/AdSense.tsx
@@ -21,6 +21,8 @@ const AdSense: React.FC<Props> = ({
     layout,
     fullWidthResponsive = true,
 }) => {
+    const preview = process.env.NODE_ENV !== 'production'
+
     useEffect(() => {
         window.adsbygoogle = window.adsbygoogle || []
         window.adsbygoogle.push({})
@@ -38,10 +40,13 @@ const AdSense: React.FC<Props> = ({
             data-ad-slot={slot}
             data-ad-format={format}
             data-ad-layout={layout}
+            data-ad-preview={preview ? 'true' : undefined}
             data-full-width-responsive={
                 fullWidthResponsive ? 'true' : undefined
             }
-        />
+        >
+            {preview ? '広告プレビュー' : null}
+        </ins>
     )
 }
 

--- a/mojacoder-frontend/components/AdSense.tsx
+++ b/mojacoder-frontend/components/AdSense.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react'
+
+import { ADSENSE_CLIENT } from '../lib/adsense'
+
+declare global {
+    interface Window {
+        adsbygoogle?: Record<string, unknown>[]
+    }
+}
+
+interface Props {
+    slot: string
+    format?: 'auto' | 'fluid'
+    layout?: string
+    fullWidthResponsive?: boolean
+}
+
+const AdSense: React.FC<Props> = ({
+    slot,
+    format = 'auto',
+    layout,
+    fullWidthResponsive = true,
+}) => {
+    useEffect(() => {
+        window.adsbygoogle = window.adsbygoogle || []
+        window.adsbygoogle.push({})
+    }, [])
+
+    return (
+        <ins
+            aria-label="広告"
+            className="adsbygoogle my-4"
+            style={{
+                display: 'block',
+                textAlign: 'center',
+            }}
+            data-ad-client={ADSENSE_CLIENT}
+            data-ad-slot={slot}
+            data-ad-format={format}
+            data-ad-layout={layout}
+            data-full-width-responsive={
+                fullWidthResponsive ? 'true' : undefined
+            }
+        />
+    )
+}
+
+export default AdSense

--- a/mojacoder-frontend/lib/adsense.ts
+++ b/mojacoder-frontend/lib/adsense.ts
@@ -1,0 +1,21 @@
+export const ADSENSE_CLIENT = 'ca-pub-1558648672247263'
+
+export const ADSENSE_SLOTS = {
+    footer: '8841155425',
+    problem: '8232681143',
+} as const
+
+const FOOTER_AD_ROUTES = new Set([
+    '/problems',
+    '/contests',
+    '/users/[username]',
+    '/users/[username]/contests',
+    '/users/[username]/contests/[contestSlug]',
+    '/users/[username]/contests/[contestSlug]/standings',
+    '/users/[username]/problems/[problemSlug]/comments',
+    '/users/[username]/problems/[problemSlug]/editorial',
+    '/users/[username]/problems/[problemSlug]/likers',
+])
+
+export const shouldShowFooterAd = (pathname: string) =>
+    FOOTER_AD_ROUTES.has(pathname)

--- a/mojacoder-frontend/pages/_app.tsx
+++ b/mojacoder-frontend/pages/_app.tsx
@@ -9,8 +9,11 @@ import Auth from '../lib/auth'
 import Session from '../lib/session'
 import Appbar from '../containers/Appbar'
 import Authenticate from '../containers/Authenticate'
+import AdSense from '../components/AdSense'
+import Layout from '../components/Layout'
 import ServiceTerminationAlert from '../components/ServiceTerminationAlert'
 import SearchEnginePolicy from '../components/SearchEnginePolicy'
+import { ADSENSE_SLOTS, shouldShowFooterAd } from '../lib/adsense'
 
 import 'nprogress/nprogress.css'
 import 'bootstrap/dist/css/bootstrap.min.css'
@@ -332,7 +335,8 @@ const languages = {
 }
 
 const App = ({ Component, pageProps }: AppProps) => {
-    const { locale, pathname } = useRouter()
+    const { asPath, locale, pathname } = useRouter()
+    const adPageKey = asPath.split(/[?#]/)[0]
     return (
         <I18nProvider defaultLanguage="ja" lang={locale} languages={languages}>
             <Auth.Provider>
@@ -351,6 +355,16 @@ const App = ({ Component, pageProps }: AppProps) => {
                     <Appbar />
                     <ServiceTerminationAlert />
                     <Component {...pageProps} />
+                    {shouldShowFooterAd(pathname) && (
+                        <Layout>
+                            <AdSense
+                                key={`footer-${adPageKey}`}
+                                slot={ADSENSE_SLOTS.footer}
+                                format="fluid"
+                                layout="in-article"
+                            />
+                        </Layout>
+                    )}
                 </Session.Provider>
             </Auth.Provider>
         </I18nProvider>

--- a/mojacoder-frontend/pages/_document.tsx
+++ b/mojacoder-frontend/pages/_document.tsx
@@ -1,15 +1,19 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 
+import { ADSENSE_CLIENT } from '../lib/adsense'
+
 class MyDocument extends Document {
     render() {
         return (
             <Html>
                 <Head>
-                    <script
-                        data-ad-client="ca-pub-1558648672247263"
-                        async
-                        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
-                    ></script>
+                    {process.env.NODE_ENV === 'production' && (
+                        <script
+                            async
+                            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
+                            crossOrigin="anonymous"
+                        ></script>
+                    )}
                 </Head>
                 <body>
                     <Main />

--- a/mojacoder-frontend/pages/index.tsx
+++ b/mojacoder-frontend/pages/index.tsx
@@ -3,8 +3,10 @@ import { MarkGithubIcon } from '@primer/octicons-react'
 import { Container, Image } from 'react-bootstrap'
 
 import IconWithText from '../components/IconWithText'
+import AdSense from '../components/AdSense'
 import Layout from '../components/Layout'
 import Title from '../components/Title'
+import { ADSENSE_SLOTS } from '../lib/adsense'
 
 const GITHUB_LINK = 'https://github.com/makutamoto/mojacoder'
 const TWITTER_LINK = 'https://twitter.com/makutamoto'
@@ -65,6 +67,13 @@ export const Index: React.FC = () => {
                         <br />
                         フォロワーのみなさんがあなたの問題を楽しんでくれるはずです！
                     </p>
+                </Layout>
+                <Layout>
+                    <AdSense
+                        slot={ADSENSE_SLOTS.footer}
+                        format="fluid"
+                        layout="in-article"
+                    />
                 </Layout>
                 <Layout>
                     <h3>寄付のお願い</h3>

--- a/mojacoder-frontend/pages/users/[username]/problems/[problemSlug]/index.tsx
+++ b/mojacoder-frontend/pages/users/[username]/problems/[problemSlug]/index.tsx
@@ -12,6 +12,8 @@ import Title from '../../../../../components/Title'
 import Heading from '../../../../../components/Heading'
 import ProblemTop from '../../../../../containers/ProblemTop'
 import SubmissionBox from '../../../../../components/SubmissionBox'
+import AdSense from '../../../../../components/AdSense'
+import { ADSENSE_SLOTS } from '../../../../../lib/adsense'
 
 interface Props {
     user: UserDetail | null
@@ -39,6 +41,12 @@ const ProblemPage: React.FC<Props> = (props) => {
                         redirect="submissions"
                     />
                 </div>
+                <AdSense
+                    key={user.problem.id}
+                    slot={ADSENSE_SLOTS.problem}
+                    format="fluid"
+                    layout="in-article"
+                />
             </Layout>
         </>
     )

--- a/mojacoder-frontend/styles/global.css
+++ b/mojacoder-frontend/styles/global.css
@@ -5,3 +5,16 @@ body {
 ins.adsbygoogle[data-ad-status='unfilled'] {
     display: none !important;
 }
+
+ins.adsbygoogle[data-ad-preview='true'] {
+    display: flex !important;
+    min-height: 120px;
+    align-items: center;
+    justify-content: center;
+    border: 1px dashed #adb5bd;
+    border-radius: 0.25rem;
+    background: #f1f3f5;
+    color: #6c757d;
+    font-size: 0.875rem;
+    text-decoration: none;
+}

--- a/mojacoder-frontend/styles/global.css
+++ b/mojacoder-frontend/styles/global.css
@@ -1,3 +1,7 @@
 body {
     background: #F8F9FA;
 }
+
+ins.adsbygoogle[data-ad-status='unfilled'] {
+    display: none !important;
+}

--- a/mojacoder-frontend/test/components/AdSense.test.tsx
+++ b/mojacoder-frontend/test/components/AdSense.test.tsx
@@ -21,6 +21,8 @@ describe('AdSense', () => {
         expect(ad?.getAttribute('data-ad-format')).toBe('fluid')
         expect(ad?.getAttribute('data-ad-layout')).toBe('in-article')
         expect(ad?.getAttribute('data-full-width-responsive')).toBe('true')
+        expect(ad?.getAttribute('data-ad-preview')).toBe('true')
+        expect(ad?.textContent).toBe('広告プレビュー')
         expect(window.adsbygoogle).toEqual([{}])
     })
 })

--- a/mojacoder-frontend/test/components/AdSense.test.tsx
+++ b/mojacoder-frontend/test/components/AdSense.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import AdSense from '../../components/AdSense'
+import { render } from '../testUtils'
+
+describe('AdSense', () => {
+    beforeEach(() => {
+        delete window.adsbygoogle
+    })
+
+    it('renders the restored ad unit and requests an ad', () => {
+        const { container } = render(
+            <AdSense slot="8841155425" format="fluid" layout="in-article" />
+        )
+        const ad = container.querySelector('ins.adsbygoogle')
+
+        expect(ad?.getAttribute('data-ad-client')).toBe(
+            'ca-pub-1558648672247263'
+        )
+        expect(ad?.getAttribute('data-ad-slot')).toBe('8841155425')
+        expect(ad?.getAttribute('data-ad-format')).toBe('fluid')
+        expect(ad?.getAttribute('data-ad-layout')).toBe('in-article')
+        expect(ad?.getAttribute('data-full-width-responsive')).toBe('true')
+        expect(window.adsbygoogle).toEqual([{}])
+    })
+})

--- a/mojacoder-frontend/test/lib/adsense.test.ts
+++ b/mojacoder-frontend/test/lib/adsense.test.ts
@@ -1,0 +1,30 @@
+import { shouldShowFooterAd } from '../../lib/adsense'
+
+describe('shouldShowFooterAd', () => {
+    it.each([
+        '/problems',
+        '/contests',
+        '/users/[username]',
+        '/users/[username]/contests/[contestSlug]',
+        '/users/[username]/problems/[problemSlug]/editorial',
+    ])('shows an ad on public content route %s', (pathname) => {
+        expect(shouldShowFooterAd(pathname)).toBe(true)
+    })
+
+    it.each([
+        '/',
+        '/signin',
+        '/signup',
+        '/settings',
+        '/playground',
+        '/problems/post',
+        '/contests/create',
+        '/users/[username]/problems/[problemSlug]',
+        '/users/[username]/problems/[problemSlug]/edit',
+        '/users/[username]/problems/[problemSlug]/testcases/[testcaseName]',
+        '/users/[username]/problems/[problemSlug]/submissions/[submissionID]',
+        '/users/[username]/contests/[contestSlug]/tasks/[taskNumber]',
+    ])('keeps action-oriented route %s ad-free', (pathname) => {
+        expect(shouldShowFooterAd(pathname)).toBe(false)
+    })
+})


### PR DESCRIPTION
## 概要

削除されていたGoogle AdSenseの広告表示を復元し、ユーザー操作を妨げにくいページ・位置へ広告を配置します。

## 変更内容

- 共通のAdSenseコンポーネントと広告設定を追加
- AdSenseスクリプトを本番環境のみ読み込むよう変更
- 以下の場所へ広告を配置
  - ホーム画面の「寄付のお願い」直前
  - 問題詳細画面の提出フォーム下
  - 問題一覧、コンテスト、ユーザーページなどの末尾
- 投稿、編集、提出、設定、Playgroundなどの操作系ページは広告対象外
- 広告が配信されなかった空枠を非表示化
- 開発環境では広告枠を「広告プレビュー」として表示
- 広告コンポーネントと表示ルート判定のテストを追加

## 確認内容

- 広告関連テスト：18件成功
- ESLint：成功
- TypeScript型検査：成功
- 開発環境のホーム画面で広告プレビューを確認